### PR TITLE
Dynamic git version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 tests/workspace
+textract2page/_version.py
 *.egg-info
 __pycache__
 build
 dist
 *~
 .vscode
+ocrd.log

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ help:
 	@echo "   test-api   Run the API tests (using pytest)"
 	@echo "   test-cli   Run the CLI tests (optionally using xmlstarlet)"
 	@echo "   test       Run both kinds of tests"
+	@echo "   build      Create source and binary pkgs under dist/"
+	@echo "   publish    Upload pkgs from dist/ to PyPI"
 	@echo
 	@echo " Variables"
 	@echo
@@ -34,4 +36,12 @@ test-cli:
 	if command -v xmlstarlet &> /dev/null; then diff -u <($(UNDATED) tests/workspace/page/18xx-Missio-EMU-0042.xml) <($(UNDATED) $(OUT)); fi
 	-$(RM) $(OUT)
 
-.PHONY: help install deps-test test test-api test-cli
+build:
+	$(PYTHON) -m pip build
+
+publish:
+	twine check dist/*
+	twine upload dist/*
+
+
+.PHONY: help install deps-test test test-api test-cli build publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]  # PEP 508 specifications.
+requires = [
+         "setuptools>=42",
+         "setuptools_scm[toml]",
+         "wheel",
+]  # PEP 508 specifications.
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "textract2page"
+dynamic = ["version"]
+
+[tool.setuptools_scm]
+write_to = "textract2page/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,4 @@
 [metadata]
-name = textract2page
-version = 0.1
 description = Convert AWS Textract JSON to PRImA PAGE XML
 author = Arne Rümmler
 author_email = arne.ruemmler@gmail.com

--- a/textract2page/__init__.py
+++ b/textract2page/__init__.py
@@ -1,5 +1,7 @@
 """convert OCR results from Amazon AWS Textract (JSON) to PRImA PAGE (XML)"""
 
 from .convert_aws import convert_file
+from ._version import version
 
 __all__ = ['convert_file']
+__version__ = version


### PR DESCRIPTION
Note: this method (setuptools_scm, in contrast to pbm) does **not** suffer the problem that untagged git heads would be rendered as 0.0.0. Instead, it automatically creates a PEP 440 compatible development pre-relase – `textract2page-0.2.dev0+gec5331c.d20230504` in my case.
