### PR TITLE
switch from setup.cfg to pyproject.toml-only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,41 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "textract2page"
-dynamic = ["version"]
+description = "Convert AWS Textract JSON to PRImA PAGE XML"
+readme = "README.md"
+authors = [
+        {name = "Arne Rümmler"},
+        {email = "arne.ruemmler@gmail.com"}
+]
+license = {text = "Apache Software License"}
+keywords = ["OCR", "METS", "PAGE-XML", "AWS"]
+classifiers = [
+            "Programming Language :: Python :: 3",
+            "Operating System :: OS Independent",
+            "License :: OSI Approved :: Apache Software License",
+            "Development Status :: 3 - Alpha",
+            "Environment :: Console",
+            "Intended Audience :: Developers",
+            "Intended Audience :: Education",
+            "Intended Audience :: Science/Research",
+            "Topic :: File Formats",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dynamic = ["version", "dependencies"]
+requires-python = ">=3.7"
+
+[project.urls]
+homepage = "https://github.com/slub/textract2page"
+
+[project.scripts]
+textract2page = "textract2page.cli:cli"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools_scm]
 write_to = "textract2page/_version.py"
+
+[[tool.mypy.overrides]]
+module = "PIL.*,ocrd_models.*,ocrd_utils.*,ocrd_modelfactory"
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,45 +1,6 @@
-[metadata]
-description = Convert AWS Textract JSON to PRImA PAGE XML
-author = Arne Rümmler
-author_email = arne.ruemmler@gmail.com
-url = https://github.com/slub/textract2page
-long_description = file: README.md
-long_description_content_type = text/markdown
-keywords = OCR,METS,PAGE-XML,AWS
-license = Apache Software License
-classifiers =
-    Programming Language :: Python :: 3
-    Operating System :: OS Independent
-    License :: OSI Approved :: Apache Software License
-    Development Status :: 3 - Alpha
-    Environment :: Console
-    Intended Audience :: Developers
-    Intended Audience :: Education
-    Intended Audience :: Science/Research
-    Topic :: File Formats
-    Topic :: Software Development :: Libraries :: Python Modules
-
-[options]
-python_requires = >=3.7
-install_requires = file:requirements.txt
-setup_requires = wheel
-packages = find:
-include_package_data = False
-
-[options.packages.find]
-include = textract2page*
-
-[options.entry_points]
-console_scripts =
-    textract2page = textract2page.cli:cli
-
-
 [flake8]
 ignore=E501
 exclude=tests/*.py
-
-[PIL.*,ocrd_models.*,ocrd_utils.*,ocrd_modelfactory]
-ignore_missing_imports = True
 
 [codespell]
 skip = ./tests,./venv*,repo,build,.git,*.egg-info


### PR DESCRIPTION
Supersedes #13.

Note: due to [pip issue](https://github.com/pypa/pip/issues/11221) / [pypa spec issue](https://github.com/pypa/packaging-problems/issues/606), the `Home-page` field will not be shown anymore (but it should work on PyPI).