### PR TITLE
Allow conversion without image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,16 @@ test-api:
 
 test-cli: OUT != mktemp -u
 test-cli: UNDATED := xmlstarlet ed -N pc=http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 -d /pc:PcGts/pc:Metadata/* -d "/pc:PcGts/pc:Page/@imageFilename"
-test-cli:
-	cd tests/workspace; textract2page -O $(OUT) textract_responses/18xx-Missio-EMU-0042.json images/18xx-Missio-EMU-0042.jpg
+test-cli: test-cli-with-image test-cli-without-image
 	if command -v xmlstarlet &> /dev/null; then diff -u <($(UNDATED) tests/workspace/reference_page_xml/18xx-Missio-EMU-0042.xml) <($(UNDATED) $(OUT)); fi
-	-$(RM) $(OUT)
+	@-$(RM) $(OUT)
+
+test-cli-with-image:
+	cd tests/workspace; textract2page -O $(OUT) textract_responses/18xx-Missio-EMU-0042.json images/18xx-Missio-EMU-0042.jpg
+
+test-cli-without-image: OPTS != identify -format "--image-width %w --image-height %h" tests/workspace/images/18xx-Missio-EMU-0042.jpg
+test-cli-without-image:
+	cd tests/workspace; textract2page -O $(OUT) $(OPTS) textract_responses/18xx-Missio-EMU-0042.json images/18xx-Missio-EMU-0042.jpg
 
 build:
 	$(PYTHON) -m pip build

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,13 +2,15 @@ from pathlib import Path
 from os import chdir
 from difflib import unified_diff
 from pytest import fixture
+from lxml import etree as ET
+from PIL import Image
+
 from ocrd_utils import pushd_popd
 from ocrd import Resolver
 from ocrd_models.ocrd_page import parseEtree
 from ocrd_models.constants import NAMESPACES as NS
-from lxml import etree as ET
 
-from textract2page import convert_file
+from textract2page import convert_file, convert_file_without_image
 
 THIS_DIR = Path(__file__).resolve().parent
 
@@ -31,6 +33,46 @@ def test_api(workspace_path, tmpdir):
     for path in test_path_dict:
         _, target_tree, _, _ = parseEtree(path["xml"], silence=True)
         convert_file(str(path["aws"]), str(path["img"]), str(tmpdir/path["xml"]))
+        _, result_tree, _, _ = parseEtree(tmpdir/path["xml"], silence=True)
+        # remove elements bearing dates (Created, LastChange, Creator/Version)
+        for meta in target_tree.xpath(
+            "/page:PcGts/page:Metadata/*",
+            namespaces=NS,
+        ) + result_tree.xpath(
+            "/page:PcGts/page:Metadata/*",
+            namespaces=NS,
+        ):
+            meta.getparent().remove(meta)
+        # remove img path from Page element
+
+        res_img_path_elem = result_tree.find(
+            "page:Page",
+            namespaces=NS,
+        )
+        del res_img_path_elem.attrib["imageFilename"]
+        tar_img_path_elem = target_tree.find(
+            "page:Page",
+            namespaces=NS,
+        )
+        del tar_img_path_elem.attrib["imageFilename"]
+        target_xml = ET.tostring(target_tree, pretty_print=True, encoding='UTF-8').decode('utf-8')
+        result_xml = ET.tostring(result_tree, pretty_print=True, encoding='UTF-8').decode('utf-8')
+        assert result_xml == target_xml, path
+
+def test_api_without_image(workspace_path, tmpdir):
+    test_path_dict = [
+        {
+            "aws": Path("textract_responses") / f"{filename.name.split('.', 1)[0]}.json",
+            "img": Path("images") / filename.name,
+            "xml": Path("reference_page_xml") / f"{filename.name.split('.', 1)[0]}.xml",
+        }
+        for filename in Path("images").iterdir()
+    ]
+    for path in test_path_dict:
+        _, target_tree, _, _ = parseEtree(path["xml"], silence=True)
+        with Image.open(str(path["img"])) as img:
+            convert_file_without_image(str(path["aws"]), str(path["img"]),
+                                       img.width, img.height, str(tmpdir/path["xml"]))
         _, result_tree, _, _ = parseEtree(tmpdir/path["xml"], silence=True)
         # remove elements bearing dates (Created, LastChange, Creator/Version)
         for meta in target_tree.xpath(

--- a/textract2page/__init__.py
+++ b/textract2page/__init__.py
@@ -1,6 +1,6 @@
 """convert OCR results from Amazon AWS Textract (JSON) to PRImA PAGE (XML)"""
 
-from .convert_aws import convert_file
+from .convert_aws import convert_file, convert_file_without_image
 from ._version import version
 
 __all__ = ['convert_file', 'convert_file_without_image']

--- a/textract2page/__init__.py
+++ b/textract2page/__init__.py
@@ -3,5 +3,5 @@
 from .convert_aws import convert_file
 from ._version import version
 
-__all__ = ['convert_file']
+__all__ = ['convert_file', 'convert_file_without_image']
 __version__ = version

--- a/textract2page/cli.py
+++ b/textract2page/cli.py
@@ -1,6 +1,6 @@
 import click
 
-from .convert_aws import convert_file
+from .convert_aws import convert_file, convert_file_without_image
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -14,19 +14,26 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     type=click.Path(dir_okay=False, writable=True, exists=False, allow_dash=True),
 )
 @click.argument("aws-json-file", type=click.Path(dir_okay=False, exists=True))
-@click.argument("image-file", type=click.Path(dir_okay=False, exists=True))
-def cli(output_file, aws_json_file, image_file):
+@click.argument("image-file", type=str)
+@click.option("--image-width", type=int, help="Width of the image in pixels, if the image isn't available.")
+@click.option("--image-height", type=int, help="Height of the image in pixels, if the image isn't available.")
+def cli(output_file, aws_json_file, image_file, image_width, image_height):
     """Convert an AWS Textract JSON file to a PAGE XML file.
 
-    Also requires the original input image of AWS OCR to get absolute image coordinates.
+    Because of differences in the way Textract JSON and PAGE XML represent coordinates,
+    either the original image file must be supplied, or the image's filename and its 
+    absolute pixel dimensions must be supplied.
 
-    The output file will reference the image file under `Page/@imageFilename`
-    with its full path. (So you may want to use a relative path.)
+    The output file will reference the image file using the name you provide.
+    (So you may want to use a relative path.)
     """
     if output_file == "-":
         output_file = None
-    convert_file(aws_json_file, image_file, output_file)
 
+    if (image_width and image_height):
+        convert_file_without_image(aws_json_file, image_file, image_width, image_height, output_file)
+    else:
+        convert_file(aws_json_file, image_file, output_file)
 
 if __name__ == "__main__":
     cli()  # pylint: disable=no-value-for-parameter

--- a/textract2page/cli.py
+++ b/textract2page/cli.py
@@ -1,4 +1,5 @@
 import click
+from os.path import exists
 
 from .convert_aws import convert_file, convert_file_without_image
 

--- a/textract2page/cli.py
+++ b/textract2page/cli.py
@@ -14,9 +14,9 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     type=click.Path(dir_okay=False, writable=True, exists=False, allow_dash=True),
 )
 @click.argument("aws-json-file", type=click.Path(dir_okay=False, exists=True))
-@click.argument("image-file", type=str)
-@click.option("--image-width", type=int, help="Width of the image in pixels, if the image isn't available.")
-@click.option("--image-height", type=int, help="Height of the image in pixels, if the image isn't available.")
+@click.argument("image-file", type=click.Path(dir_okay=False, exists=False))
+@click.option("--image-width", type=int, help="width of the image in pixels (to avoid opening the image file)")
+@click.option("--image-height", type=int, help="height of the image in pixels (to avoid opening the image file)")
 def cli(output_file, aws_json_file, image_file, image_width, image_height):
     """Convert an AWS Textract JSON file to a PAGE XML file.
 
@@ -27,6 +27,8 @@ def cli(output_file, aws_json_file, image_file, image_width, image_height):
     The output file will reference the image file using the name you provide.
     (So you may want to use a relative path.)
     """
+    assert image_width and image_height or image_file and exists(image_file),\
+        "requires passing either an existing image file path or --image-width and --image-height"
     if output_file == "-":
         output_file = None
 

--- a/textract2page/convert_aws.py
+++ b/textract2page/convert_aws.py
@@ -712,7 +712,32 @@ def convert_file(json_path: str, img_path: str, out_path: str) -> None:
 
     Arguments:
         json_path (str): path to input JSON file
-        img_path (str): path to input JPEG file
+        img_path (str): path to input image file
+        out_path (str): path to output XML file
+    """
+    
+    # get absolute image coordinates
+    pil_img = Image.open(img_path)
+    img_width = pil_img.width
+    img_height = pil_img.height
+    pil_img.close()
+    
+    convert_file_without_image(json_path, img_path, img_width, img_height, out_path)
+
+
+def convert_file_without_image(json_path: str, img_path: str, img_width: int, img_height: int, out_path: str) -> None:
+    """Convert an AWS-Textract-JSON file to a PAGE-XML file, without the original input image.
+
+    Requires the absolute dimensions of the original input image used for AWS OCR.
+    (If the image is available, call convert_file instead.)
+
+    Amazon Documentation: https://docs.aws.amazon.com/textract/latest/dg/how-it-works-document-layout.html
+
+    Arguments:
+        json_path (str): path to input JSON file
+        img_path (str): filename of input image file
+        img_width (int): width of image in pixels
+        img_height (int): height of image in pixels
         out_path (str): path to output XML file
     """
 
@@ -915,10 +940,6 @@ def convert_file(json_path: str, img_path: str, out_path: str) -> None:
         textract_objects_in_reading_order = text_regions
 
     # build PRIMAPageXML
-    pil_img = Image.open(img_path)
-    img_width = pil_img.width
-    img_height = pil_img.height
-    pil_img.close()
     now = datetime.now()
     page_content_type = PcGtsType(
         Metadata=MetadataType(

--- a/textract2page/convert_aws.py
+++ b/textract2page/convert_aws.py
@@ -728,8 +728,9 @@ def convert_file(json_path: str, img_path: str, out_path: str) -> None:
 def convert_file_without_image(json_path: str, img_path: str, img_width: int, img_height: int, out_path: str) -> None:
     """Convert an AWS-Textract-JSON file to a PAGE-XML file, without the original input image.
 
-    Requires the absolute dimensions of the original input image used for AWS OCR.
-    (If the image is available, call convert_file instead.)
+    Also requires the original input image used for AWS OCR, but only to reference it under 
+    `Page/@imageFilename` with its full path – does not actually require an existing file under that path.
+    Instead, this additionally requires the absolute dimensions (pixel resolution) of the image.
 
     Amazon Documentation: https://docs.aws.amazon.com/textract/latest/dg/how-it-works-document-layout.html
 


### PR DESCRIPTION
As proposed in #25, this PR adds a `convert_file_without_image` function, which can convert AWS-Textract-JSON to PAGE-XML without needing to read the original input image. This function takes the image’s dimensions as inputs, instead of reading these from the image.

The PR also adds “image-width” and “image-height” options to the CLI command, which triggers the use of the new function if they are supplied.

I lack python skills and cobbled this together, so pardon the lack of tests covering the new functionality. 

I did run `make test-api`, which passed. (But `make test-cli` failed with the same error as before my changes ("No rule to make target `OUT`, needed by `test-cli`. Stop.")

I performed the following tests manually, confirming that the results were as expected:

**Test 1: Using original features**

The following command uses the original features of the utility:

```bash
textract2page --output-file page.xml tesseract.json source.jpg
```

... returned a 66k PAGE-XML file, with the following excerpt on line 8 referencing the input image file:

```xml
<pc:Page imageFilename="source.jpg" imageWidth="4593" imageHeight="7163">
```

**Test 2: Using the new features via CLI**

The following command uses the new features added in this PR:

```bash
textract2page --output-file page2.xml tesseract.json foo.bar --image-width 4593 --image-height 7163
```

... returned an identical file, except for the following excerpt on line 8, corresponding to the one above:

```xml
<pc:Page imageFilename="foo.bar" imageWidth="4593" imageHeight="7163">
```

I'd greatly appreciate any feedback!